### PR TITLE
chore: VS Codeワークスペースファイルを削除

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stockvalue-exporter"
-version = "2.1.3"
+version = "2.1.4"
 description = "A Prometheus custom exporter for real-time stock price monitoring and metrics collection"
 authors = [
     {name = "mizu", email = "mizu.copo@gmail.com"}

--- a/stockvalue-exporter.code-workspace
+++ b/stockvalue-exporter.code-workspace
@@ -1,8 +1,0 @@
-{
-	"folders": [
-		{
-			"path": "."
-		}
-	],
-	"settings": {}
-}

--- a/uv.lock
+++ b/uv.lock
@@ -726,7 +726,7 @@ wheels = [
 
 [[package]]
 name = "stockvalue-exporter"
-version = "2.1.3"
+version = "2.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },


### PR DESCRIPTION
## 概要

- リポジトリ固有の `stockvalue-exporter.code-workspace` を削除
- プロジェクトバージョンを `2.1.3` から `2.1.4` に更新

## 検証

- `uv run task test`（141 tests passed、coverage 86.53%）
- `uv lock --check`（バージョン更新前後で成功）

## 影響

- アプリケーションコードや利用者向けインターフェースへの変更なし
- 移行作業なし

Closes #50