### PR TITLE
fix: コンテナを非rootユーザーで実行する

### DIFF
--- a/.github/workflows/pr-quality-checks.yml
+++ b/.github/workflows/pr-quality-checks.yml
@@ -48,6 +48,40 @@ jobs:
         continue-on-error: true
         run: uv run ruff check .
 
+      - name: Verify container runtime
+        id: container-runtime
+        continue-on-error: true
+        timeout-minutes: 10
+        run: |
+          IMAGE="stockvalue-exporter:pr-quality-check"
+          CONTAINER="stockvalue-exporter-pr-quality-check"
+
+          trap 'docker rm -f "$CONTAINER" >/dev/null 2>&1 || true' EXIT
+
+          docker build --tag "$IMAGE" .
+          docker run --rm --entrypoint sh "$IMAGE" -c '
+            test "$(id -u)" -eq 10001
+            test "$(id -g)" -eq 10001
+            test "$HOME" = /home/appuser
+            test "$XDG_CACHE_HOME" = /home/appuser/.cache
+            test -w "$XDG_CACHE_HOME"
+            test ! -w /app
+            touch "$XDG_CACHE_HOME/.write-test"
+          '
+
+          docker run --detach --name "$CONTAINER" \
+            --publish 127.0.0.1:19100:9100 "$IMAGE"
+          for _ in $(seq 1 30); do
+            if curl --fail --silent --show-error \
+              http://127.0.0.1:19100/health >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          docker logs "$CONTAINER"
+          exit 1
+
       - name: Build quality check summary
         id: quality-report
         if: ${{ !cancelled() }}
@@ -56,6 +90,7 @@ jobs:
           MYPY_OUTCOME: ${{ steps.mypy.outcome }}
           RUFF_FORMAT_OUTCOME: ${{ steps.ruff-format.outcome }}
           RUFF_CHECK_OUTCOME: ${{ steps.ruff-check.outcome }}
+          CONTAINER_RUNTIME_OUTCOME: ${{ steps.container-runtime.outcome }}
         run: |
           format_result() {
             case "$1" in
@@ -75,6 +110,7 @@ jobs:
           | mypy | $(format_result "$MYPY_OUTCOME") |
           | ruff format | $(format_result "$RUFF_FORMAT_OUTCOME") |
           | ruff check | $(format_result "$RUFF_CHECK_OUTCOME") |
+          | container runtime | $(format_result "$CONTAINER_RUNTIME_OUTCOME") |
           EOF
 
           cat quality_report.md >> "$GITHUB_STEP_SUMMARY"
@@ -84,7 +120,8 @@ jobs:
             "$PYTEST_OUTCOME" \
             "$MYPY_OUTCOME" \
             "$RUFF_FORMAT_OUTCOME" \
-            "$RUFF_CHECK_OUTCOME"; do
+            "$RUFF_CHECK_OUTCOME" \
+            "$CONTAINER_RUNTIME_OUTCOME"; do
             if [ "$outcome" != "success" ]; then
               HAS_FAILURE=true
             fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,16 @@ RUN apk add --no-cache \
 # 実行ステージ
 FROM python:3.14.6-alpine
 
+ARG APP_UID=10001
+ARG APP_GID=10001
+
 COPY --from=builder /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
 COPY --from=builder /etc/timezone /etc/timezone
+
+RUN addgroup -S -g "${APP_GID}" appgroup \
+    && adduser -S -D -u "${APP_UID}" -G appgroup -h /home/appuser appuser \
+    && mkdir -p /home/appuser/.cache \
+    && chown -R appuser:appgroup /home/appuser
 
 ENV PIP_ROOT_USER_ACTION=ignore
 
@@ -37,6 +45,11 @@ RUN uv sync --locked --no-dev
 
 RUN rm /app/.python-version \
     && rm /app/uv.lock
+
+ENV HOME=/home/appuser \
+    XDG_CACHE_HOME=/home/appuser/.cache
+
+USER appuser:appgroup
 
 EXPOSE 9100
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,10 @@
 FROM mizucopo/stockvalue-exporter:latest
 
+ARG APP_UID=10001
+ARG APP_GID=10001
+
+USER root
+
 COPY .python-version \
      pyproject.toml \
      uv.lock \
@@ -14,4 +19,17 @@ RUN apk add --no-cache --virtual .build-deps \
       musl-dev \
       python3-dev \
     && uv sync --locked \
-    && apk del .build-deps
+    && apk del .build-deps \
+    && (getent group appgroup >/dev/null 2>&1 \
+        || addgroup -S -g "${APP_GID}" appgroup) \
+    && (id -u appuser >/dev/null 2>&1 \
+        || adduser -S -D -u "${APP_UID}" -G appgroup -h /home/appuser appuser) \
+    && test "$(id -u appuser)" -eq "${APP_UID}" \
+    && test "$(id -g appuser)" -eq "${APP_GID}" \
+    && mkdir -p /home/appuser/.cache \
+    && chown -R appuser:appgroup /home/appuser
+
+ENV HOME=/home/appuser \
+    XDG_CACHE_HOME=/home/appuser/.cache
+
+USER appuser:appgroup

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Docker イメージを起動します。
 docker run --rm -p 9100:9100 mizucopo/stockvalue-exporter:latest
 ```
 
+コンテナは専用の `appuser`（UID/GID `10001:10001`）で実行されます。
+アプリケーションの配置先 `/app` は実行時に書き込み不可で、必要なキャッシュは
+`/home/appuser/.cache` に保存されます。
+
 起動後、メトリクスを取得できます。
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stockvalue-exporter"
-version = "2.1.18"
+version = "2.1.19"
 description = "A Prometheus custom exporter for real-time stock price monitoring and metrics collection"
 authors = [
     {name = "mizu", email = "mizu.copo@gmail.com"}

--- a/uv.lock
+++ b/uv.lock
@@ -876,7 +876,7 @@ wheels = [
 
 [[package]]
 name = "stockvalue-exporter"
-version = "2.1.18"
+version = "2.1.19"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },


### PR DESCRIPTION
## 概要

- 本番・開発コンテナを固定UID/GID `10001:10001` の `appuser` で実行
- `/app` はroot所有のまま保ち、キャッシュ用ホームディレクトリだけを書き込み可能に制限
- PR品質チェックへ非root実行、権限、ヘルスチェックのコンテナ回帰検証を追加
- READMEへコンテナ実行ユーザーと書き込み先を追記
- プロジェクトバージョンを `2.1.19` に更新

## 検証

- `uv run task test`（141 tests passed、coverage 87.13%）
- `actionlint .github/workflows/pr-quality-checks.yml`
- 本番イメージのビルド、UID/GID・権限・yfinanceキャッシュ初期化・`/health`応答を確認
- `linux/amd64` 開発イメージのビルドとUID/GID・権限を確認
- バージョン更新前後に `uv lock --check`

Closes #18