### PR TITLE
fix: リリースタグ作者をCopier設定に統一

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,4 +1,4 @@
-_commit: 9f5027b
+_commit: 3e379ad
 _src_path: git@github.com:mizucopo/repo-template.git
 author_email: mizu.copo@gmail.com
 author_name: mizu

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -29,16 +29,13 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Read git author
-        id: author
-        run: |
-          echo "name=$(git log -1 --format=%an)" >> $GITHUB_OUTPUT
-          echo "email=$(git log -1 --format=%ae)" >> $GITHUB_OUTPUT
-
       - name: Configure Git
+        env:
+          GIT_USER_NAME: "mizu"
+          GIT_USER_EMAIL: "mizu.copo@gmail.com"
         run: |
-          git config user.name "${{ steps.author.outputs.name }}"
-          git config user.email "${{ steps.author.outputs.email }}"
+          git config user.name "$GIT_USER_NAME"
+          git config user.email "$GIT_USER_EMAIL"
 
       - name: Check if tag exists
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stockvalue-exporter"
-version = "2.1.19"
+version = "2.1.20"
 description = "A Prometheus custom exporter for real-time stock price monitoring and metrics collection"
 authors = [
     {name = "mizu", email = "mizu.copo@gmail.com"}

--- a/uv.lock
+++ b/uv.lock
@@ -876,7 +876,7 @@ wheels = [
 
 [[package]]
 name = "stockvalue-exporter"
-version = "2.1.19"
+version = "2.1.20"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },


### PR DESCRIPTION
## 概要

- repo-template PR #34 を Copier update で取り込み
- リリースタグ作者を直近コミット作者ではなく Copier の `author_name` / `author_email` から設定
- プロジェクトバージョンを `2.1.20` に更新

## 検証

- `uv run task test`（141 tests、coverage 87.13%）
- `actionlint .github/workflows/docker-release.yml`
- バージョン更新前後の `uv lock --check`
- `git diff --check`

## 関連

- Upstream: https://github.com/mizucopo/repo-template/pull/34
- Closes #25
